### PR TITLE
Add MSC SCSI start callback

### DIFF
--- a/src/arduino/msc/Adafruit_USBD_MSC.cpp
+++ b/src/arduino/msc/Adafruit_USBD_MSC.cpp
@@ -247,6 +247,17 @@ TU_ATTR_WEAK int32_t tud_msc_scsi_cb(uint8_t lun, const uint8_t scsi_cmd[16],
   return resplen;
 }
 
+// Invoked when a valid SCSI command is received (before data stage)
+TU_ATTR_WEAK void tud_msc_scsi_cmd_start_cb(uint8_t lun,
+                                            uint8_t const scsi_cmd[16],
+                                            bool dir_in,
+                                            uint32_t total_bytes) {
+  (void)lun;
+  (void)scsi_cmd;
+  (void)dir_in;
+  (void)total_bytes;
+}
+
 // Callback invoked on start/stop
 bool tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start,
                            bool load_eject) {

--- a/src/class/msc/msc_device.c
+++ b/src/class/msc/msc_device.c
@@ -422,6 +422,8 @@ bool mscd_xfer_cb(uint8_t rhport, uint8_t ep_addr, xfer_result_t event, uint32_t
 
       TU_LOG_DRV("  SCSI Command [Lun%u]: %s\r\n", p_cbw->lun, tu_lookup_find(&_msc_scsi_cmd_table, p_cbw->command[0]));
       //TU_LOG_MEM(MSC_DEBUG, p_cbw, xferred_bytes, 2);
+      tud_msc_scsi_cmd_start_cb(p_cbw->lun, p_cbw->command,
+                                is_data_in(p_cbw->dir), p_cbw->total_bytes);
 
       p_csw->signature    = MSC_CSW_SIGNATURE;
       p_csw->tag          = p_cbw->tag;

--- a/src/class/msc/msc_device.h
+++ b/src/class/msc/msc_device.h
@@ -147,6 +147,14 @@ void tud_msc_capacity_cb(uint8_t lun, uint32_t *block_count,
 TU_ATTR_WEAK int32_t tud_msc_scsi_cb(uint8_t lun, uint8_t const scsi_cmd[16],
                                      void *buffer, uint16_t bufsize);
 
+// Invoked when a valid SCSI command is received (before data stage).
+// This can be used to inspect or log the command. `dir_in` indicates
+// device-to-host transfers and `total_bytes` is the expected length.
+TU_ATTR_WEAK void tud_msc_scsi_cmd_start_cb(uint8_t lun,
+                                            uint8_t const scsi_cmd[16],
+                                            bool dir_in,
+                                            uint32_t total_bytes);
+
 /*------------- Optional callbacks -------------*/
 
 // Invoked when received GET_MAX_LUN request, required for multiple LUNs


### PR DESCRIPTION
## Summary
- add `tud_msc_scsi_cmd_start_cb` declaration for user logging
- implement empty default definition
- invoke the callback when a command is received

## Testing
- `pre-commit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840a51a2fcc8327b7c110196282165c